### PR TITLE
Always clip to *greater* positions when wrapAtSoftNewlines is true

### DIFF
--- a/spec/display-buffer-spec.coffee
+++ b/spec/display-buffer-spec.coffee
@@ -196,7 +196,7 @@ describe "DisplayBuffer", ->
         expect(displayBuffer.bufferPositionForScreenPosition([3, 5])).toEqual([3, 5])
         expect(displayBuffer.screenPositionForBufferPosition([3, 50])).toEqual([3, 50])
         expect(displayBuffer.screenPositionForBufferPosition([3, 51])).toEqual([3, 50])
-        expect(displayBuffer.bufferPositionForScreenPosition([4, 0])).toEqual([3, 51])
+        expect(displayBuffer.bufferPositionForScreenPosition([4, 0])).toEqual([3, 50])
         expect(displayBuffer.bufferPositionForScreenPosition([3, 50])).toEqual([3, 50])
         expect(displayBuffer.screenPositionForBufferPosition([3, 62])).toEqual([4, 15])
         expect(displayBuffer.bufferPositionForScreenPosition([4, 11])).toEqual([3, 58])
@@ -622,10 +622,10 @@ describe "DisplayBuffer", ->
         expect(displayBuffer.clipScreenPosition([3, 58])).toEqual [3, 50]
         expect(displayBuffer.clipScreenPosition([3, 1000])).toEqual [3, 50]
 
-      it "clips positions inside a phantom token to the beginning of the line", ->
-        expect(displayBuffer.clipScreenPosition([4, 0])).toEqual [4, 4]
-        expect(displayBuffer.clipScreenPosition([4, 1])).toEqual [4, 4]
-        expect(displayBuffer.clipScreenPosition([4, 3])).toEqual [4, 4]
+      it "wraps positions inside a phantom token to the previous line", ->
+        expect(displayBuffer.clipScreenPosition([4, 0])).toEqual [3, 50]
+        expect(displayBuffer.clipScreenPosition([4, 1])).toEqual [3, 50]
+        expect(displayBuffer.clipScreenPosition([4, 3])).toEqual [3, 50]
 
     describe "when wrapAtSoftNewlines is true", ->
       it "wraps positions at the end of soft-wrapped lines to the next screen line", ->
@@ -634,10 +634,10 @@ describe "DisplayBuffer", ->
         expect(displayBuffer.clipScreenPosition([3, 58], wrapAtSoftNewlines: true)).toEqual [4, 4]
         expect(displayBuffer.clipScreenPosition([3, 1000], wrapAtSoftNewlines: true)).toEqual [4, 4]
 
-      it "wraps positions inside a phantom token to the previous line", ->
-        expect(displayBuffer.clipScreenPosition([4, 0], wrapAtSoftNewlines: true)).toEqual [3, 50]
-        expect(displayBuffer.clipScreenPosition([4, 1], wrapAtSoftNewlines: true)).toEqual [3, 50]
-        expect(displayBuffer.clipScreenPosition([4, 3], wrapAtSoftNewlines: true)).toEqual [3, 50]
+      it "clips positions inside a phantom token to the right, at the beginning of the soft-wrapped line's continuation", ->
+        expect(displayBuffer.clipScreenPosition([4, 0], wrapAtSoftNewlines: true)).toEqual [4, 4]
+        expect(displayBuffer.clipScreenPosition([4, 1], wrapAtSoftNewlines: true)).toEqual [4, 4]
+        expect(displayBuffer.clipScreenPosition([4, 3], wrapAtSoftNewlines: true)).toEqual [4, 4]
 
     describe "when skipAtomicTokens is false (the default)", ->
       it "clips screen positions in the middle of atomic tab characters to the beginning of the character", ->
@@ -671,7 +671,7 @@ describe "DisplayBuffer", ->
       displayBuffer.setSoftWrapped(true)
       displayBuffer.setEditorWidthInChars(10)
       expect(displayBuffer.screenPositionForBufferPosition([0, 10], wrapAtSoftNewlines: true)).toEqual [1, 4]
-      expect(displayBuffer.bufferPositionForScreenPosition([1, 0])).toEqual [0, 10]
+      expect(displayBuffer.bufferPositionForScreenPosition([1, 0])).toEqual [0, 9]
 
   describe "::getMaxLineLength()", ->
     it "returns the length of the longest screen line", ->

--- a/spec/text-editor-spec.coffee
+++ b/spec/text-editor-spec.coffee
@@ -287,7 +287,7 @@ describe "TextEditor", ->
 
         it "positions the cursor at the buffer position that corresponds to the given screen position", ->
           editor.setCursorScreenPosition([9, 0])
-          expect(editor.getCursorBufferPosition()).toEqual [8, 11]
+          expect(editor.getCursorBufferPosition()).toEqual [8, 10]
 
     describe ".moveUp()", ->
       it "moves the cursor up", ->
@@ -374,6 +374,16 @@ describe "TextEditor", ->
           editor.moveDown()
           editor.moveUp()
           expect(editor.getCursorScreenPosition().column).toBe 0
+
+      describe "when the cursor is at the beginning of an indented soft-wrapped line", ->
+        it "moves to the beginning of the line's continuation on the next screen row", ->
+          editor.setSoftWrapped(true)
+          editor.setEditorWidthInChars(50)
+          editor.logScreenLines()
+
+          editor.setCursorScreenPosition([3, 0])
+          editor.moveDown()
+          expect(editor.getCursorScreenPosition()).toEqual [4, 4]
 
       describe "when there is a selection", ->
         beforeEach ->

--- a/src/display-buffer.coffee
+++ b/src/display-buffer.coffee
@@ -846,10 +846,10 @@ class DisplayBuffer extends Model
         column = screenLine.clipScreenColumn(maxScreenColumn - 1)
     else if screenLine.isColumnInsidePhantomToken(column)
       if wrapAtSoftNewlines
+        column = screenLine.clipScreenColumn(0)
+      else
         row--
         column = @screenLines[row].getMaxScreenColumn() - 1
-      else
-        column = screenLine.clipScreenColumn(0)
     else if wrapBeyondNewlines and column > maxScreenColumn and row < @getLastRow()
       row++
       column = 0


### PR DESCRIPTION
This adjusts the behavior of DisplayBuffer::clipScreenPosition to clip
to a greater position if wrapAtSoftNewlines is true. This requires
`wrapAtSoftNewlines: true` to be passed when moving the cursor down,
which makes intuitive sense.

I also adjusted many specs to account for correctly clipping backward
by one column when moving backward across a soft-wrap boundary.